### PR TITLE
Proposal for nesting query predicate operator

### DIFF
--- a/queries/nix.scm
+++ b/queries/nix.scm
@@ -255,76 +255,16 @@
 ;;!  ^^^^^^
 ;;!  xxxxxxx
 ;;!  ----------------
-(apply_expression
-  [
-    (apply_expression
-      function: (variable_expression
-        name: (identifier) @functionCallee
-      )
-    )
-    (apply_expression
-      [
-        (apply_expression
-          function: (variable_expression
-            name: (identifier) @functionCallee
-          )
-        )
-        (apply_expression
-          [
-            (apply_expression
-              function: (variable_expression
-                name: (identifier) @functionCallee
-              )
-            )
-            (apply_expression
-              (apply_expression
-                function: (variable_expression
-                  name: (identifier) @functionCallee
-                )
-              )
-            )
-          ]
-        )
-      ]
-    )
-  ]
-) @functionCall @_.domain
+(
+  (apply_expression
+    function: (_) @functionCallee
+  ) @functionCallee.domain @functionCall
+  (#not-type? @functionCallee apply_expression)
+)
 
-;; Similar to above, but sometimes the function calls are in select_expression
 (apply_expression
-  [
-    (select_expression
-      expression: (variable_expression
-        name: (identifier)
-      )
-    ) @functionCallee
-    (apply_expression
-      [
-        (select_expression
-          expression: (variable_expression
-            name: (identifier)
-          )
-        ) @functionCallee
-        (apply_expression
-          [
-            (select_expression
-              expression: (variable_expression
-                name: (identifier)
-              )
-            ) @functionCallee
-            (apply_expression
-              (select_expression
-                expression: (variable_expression
-                  name: (identifier)
-                )
-              ) @functionCallee
-            )
-          ]
-        )
-      ]
-    )
-  ]
-) @functionCall @_.domain
+  function: (apply_expression) @functionCallee.domain.input @functionCall.input
+) @functionCallee.domain.output @functionCall.output
 
 ;; Args:
 ;;!! mkHost a
@@ -337,14 +277,12 @@
 ;;!  xxxxxx
 ;;!  --------
 (apply_expression
-  function: (variable_expression
-    name: (identifier) @functionCallee
-  )
   argument: (_) @argumentOrParameter
-) @functionCall @_.domain
+)
 
-(apply_expression
-  argument: (_) @argumentOrParameter
+(
+  (apply_expression) @argumentOrParameter.iteration
+  (#not-parent-type? @argumentOrParameter.iteration apply_expression)
 )
 
 ;;


### PR DESCRIPTION
The idea here is to define `@foo.input` / `@foo.output` pairs. For any `@foo` capture, we look to see if there are any `@foo.input` captures whose range is identical to `@foo`. If so, we change the range of `@foo` to be the range of `@foo.output`. We repeat this process until it doesn't match any `@foo.input` capture. This way we can expand up an ancestor tree, traverse across a tree, etc

I haven't implemented the operator itself, but I don't think it should be too bad; just do an initial traversal where construct a map of all `@foo.input` captures and then use that for doing a lookup when we handle the final captures

cc/ @andreasarvidsson @wenkokke @josharian

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
